### PR TITLE
feat: update CAN baudrate and add LED3 channel

### DIFF
--- a/MCAL/McalGen/Can_Cfg.h
+++ b/MCAL/McalGen/Can_Cfg.h
@@ -18,7 +18,7 @@
 // Number of controller configs
 #define CAN_ARC_CTRL_CONFIG_CNT			1
 
-#define CAN_DEV_ERROR_DETECT			STD_ON
+#define CAN_DEV_ERROR_DETECT			STD_OFF
 #define CAN_VERSION_INFO_API			STD_ON
 #define CAN_MULTIPLEXED_TRANSMISSION	STD_OFF  // Not supported
 #define CAN_WAKEUP_SUPPORT				STD_OFF  // Not supported

--- a/MCAL/McalGen/Can_PBcfg.c
+++ b/MCAL/McalGen/Can_PBcfg.c
@@ -37,7 +37,7 @@ SECTION_POSTBUILD_DATA const Can_HardwareObjectType CanHardwareObjectConfig_CanC
 SECTION_POSTBUILD_DATA  const  Can_ControllerBaudrateConfigType Can_SupportedBaudrates_CanController[] =
 {
 	{
-		.CanControllerBaudRate = 		500,
+		.CanControllerBaudRate = 		250,
 		.CanControllerPropSeg =			8,
 		.CanControllerSeg1 =			5,
 		.CanControllerSeg2 =			4,
@@ -61,7 +61,7 @@ SECTION_POSTBUILD_DATA  const  Can_ControllerConfigType CanControllerConfigData[
 #if defined(CFG_CAN_USE_SYMBOLIC_CANIF_CONTROLLER_ID)
     	.Can_Arc_CanIfControllerId = NO_CANIF_CONTROLLER,
 #endif
-		.CanControllerDefaultBaudrate = 500,
+		.CanControllerDefaultBaudrate = 250,
     	.CanControllerSupportedBaudrates = Can_SupportedBaudrates_CanController,
     	.CanControllerSupportedBaudratesCount = 1,
     	 	 	

--- a/MCAL/McalGen/Dio_Cfg.h
+++ b/MCAL/McalGen/Dio_Cfg.h
@@ -41,6 +41,8 @@ typedef enum {
 #define Dio_LED1 DioConf_DioChannel_LED1
 #define DioConf_DioChannel_LED2 61
 #define Dio_LED2 DioConf_DioChannel_LED2
+#define DioConf_DioChannel_LED3 62
+#define Dio_LED3 DioConf_DioChannel_LED3
 
 // Channel groups
 


### PR DESCRIPTION
## Changes

- Updated CAN controller baud rate from 500 to 250 kbps for improved noise immunity
- Disabled CAN development error detection for production build
- Added new DIO channel LED3 on pin 62 for status indicator

## Testing
- Verified compilation on STM32F107 target
- Tested CAN communication at new baud rate